### PR TITLE
Fix default configuration on "readme.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For example, to change the `indentation` to tabs, turn off the `number-leading-z
         "composes"
       ]
     }],
-    "unit-whitelist": ["em", "rem", "s"]
+    "unit-whitelist": ["em", "rem", "s", "px"]
   }
 }
 ```


### PR DESCRIPTION
I've used configuration from readme and found out that there is no "px" in allowed list