### PR TITLE
Add ignore for custom properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,11 @@ module.exports = {
 
     'number-leading-zero': 'always',
     'number-no-trailing-zeros': true,
-    'length-zero-no-unit': true,
+    'length-zero-no-unit': [true, {
+      'ignore': [
+        "custom-properties"
+      ]
+    }],
 
     'string-quotes': 'double',
 


### PR DESCRIPTION
Кастомные свойства уже никуда не запрятать, и есть смысл достаточно сильных студентов учить использовать их для большего удобства разработки, читабельности и поддерживаемости кода.

Но вот это правило вставляет палки в колёса, когда кастомное свойство используется в расчётах, но при объявлении свойства надо указать нулевое значение. Линтер требует убрать размерность, а без неё `calc()` ломается.

Чтобы не приходилось выкручиваться чем-то вроде:
` --my-prop: calc(0 * 1px); `
(что крайне неудобно, особенно, если ещё и предполагается, что значение должно скриптом считываться) надо добавить иннорирование этим правилом кастомных свойств.

---

[Пулреквест в кодгайд](https://github.com/htmlacademy/codeguide/pull/61).