### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "scss": "stylelint test/sass/**/*.scss --config index.js --syntax scss"
   },
   "dependencies": {
-    "stylelint-config-recommended": "^5.0.0"
+    "stylelint-config-recommended": "^7.0.0"
   }
 }


### PR DESCRIPTION
В 5-ой версии есть старое правило, которое уже выпили из stylelint, из-за этого выдает кучу ошибок `Unknown rule function-calc-no-invalid`

https://stylelint.io/migration-guide/to-14/#function-calc-no-invalid-rule