### PR TITLE
Take back control of descending specificity

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ module.exports = {
       ]
     }],
 
-    'no-descending-specificity' : null,
     'no-duplicate-at-import-rules' : true,
     'no-invalid-position-at-import-rule': true,
 
@@ -63,28 +62,21 @@ module.exports = {
 
     'function-url-quotes': 'always',
 
-    'import-notation': null,
-
     'keyframe-selector-notation': 'percentage-unless-within-keyword-only-block',
 
     'number-max-precision' : 2,
 
     'value-no-vendor-prefix': true,
 
-    'property-allowed-list': null,
-    'property-disallowed-list': null,
     'property-no-vendor-prefix': true,
 
     'declaration-no-important' : true,
-    'declaration-property-max-values': null,
 
     'selector-attribute-quotes': 'always',
     'selector-max-id': 0,
     'selector-max-universal': 2,
     'selector-not-notation': 'simple',
     'selector-pseudo-element-colon-notation': 'double',
-
-    'rule-selector-property-disallowed-list': null,
 
     'media-feature-name-no-vendor-prefix': true,
 

--- a/test/css/style.css
+++ b/test/css/style.css
@@ -1080,7 +1080,12 @@
   }
 }
 
+.product-list__icon--toys path {
+  opacity: var(--path-opacity);
+}
+
 .product-list__item--toys:hover .product-list__icon--toys {
+  --path-opacity: 0.7;
   top: 16px;
 }
 
@@ -1088,10 +1093,6 @@
   .product-list__item--toys:hover .product-list__icon--toys {
     top: 26px;
   }
-}
-
-.product-list__item--toys:hover .product-list__icon--toys path {
-  opacity: 0.7;
 }
 
 .product-list__item--toys:active {
@@ -1112,6 +1113,7 @@
 }
 
 .product-list__item--toys:active .product-list__icon--toys {
+  --path-opacity: 0.3;
   top: 21px;
 }
 
@@ -1119,10 +1121,6 @@
   .product-list__item--toys:active .product-list__icon--toys {
     top: 31px;
   }
-}
-
-.product-list__item--toys:active .product-list__icon--toys path {
-  opacity: 0.3;
 }
 
 .promo {

--- a/test/sass/blocks/checkbox.scss
+++ b/test/sass/blocks/checkbox.scss
@@ -47,6 +47,10 @@
   border: 1px solid $special-dark-grey2;
 }
 
+.checkbox__input:disabled + .checkbox__label::before {
+  opacity: 0.3;
+}
+
 .checkbox__input:checked + .checkbox__label::before {
   background: url("../../img/different/tick.svg") no-repeat;
 
@@ -57,8 +61,4 @@
 
 .checkbox__input:checked:hover + .checkbox__label::before {
   border: 1px solid $special-dark-grey2;
-}
-
-.checkbox__input:disabled + .checkbox__label::before {
-  opacity: 0.3;
 }

--- a/test/sass/blocks/effect.scss
+++ b/test/sass/blocks/effect.scss
@@ -46,16 +46,6 @@
   }
 }
 
-.effect__item--weight-gain .effect__item-text {
-  @media (min-width: $tablet-width) {
-    width: 342px;
-  }
-
-  @media (min-width: $desktop-width) {
-    width: 457px;
-  }
-}
-
 .effect__item-title {
   font-family: "Oswald", "Arial", sans-serif;
   font-weight: 400;
@@ -109,6 +99,16 @@
   @media (min-width: $desktop-width) {
     width: 467px;
     margin-bottom: 27px;
+  }
+
+  .effect__item--weight-gain & {
+    @media (min-width: $tablet-width) {
+      width: 342px;
+    }
+
+    @media (min-width: $desktop-width) {
+      width: 457px;
+    }
   }
 }
 

--- a/test/sass/blocks/radio.scss
+++ b/test/sass/blocks/radio.scss
@@ -41,6 +41,10 @@
   border: 1px solid $special-dark-grey2;
 }
 
+.radio__input:disabled + .radio__label::before {
+  opacity: 0.3;
+}
+
 .radio__input:checked + .radio__label::before {
   background-color: $special-green;
   box-shadow: inset 0 0 0 7px $basic-white;
@@ -52,9 +56,4 @@
 
 .radio__input:checked:hover + .radio__label::before {
   border: 1px solid $special-dark-grey2;
-}
-
-
-.radio__input:disabled + .radio__label::before {
-  opacity: 0.3;
 }


### PR DESCRIPTION
Resolve #30

Основное — это удаление отключения `no-descending-specificity`, которое включено в recommended-конфиг.

Остальные пять отключений удалил просто до кучи, для порядка. Их нет в recommended, соответственно и отключать их нет нужды. В этом конфиге эти отключения ничего не делают, просто информационный шум.